### PR TITLE
Add scraped month to pipeline; add sql statements modifying original db

### DIFF
--- a/dealerships_scraper/pipelines.py
+++ b/dealerships_scraper/pipelines.py
@@ -35,7 +35,9 @@ class DealershipsScraperPipeline:
         dealership_city varchar,
         dealership_state varchar,
         scraped_url varchar,
-        scraped_date timestamp
+        scraped_date timestamp,
+        scraped_month date not null,
+        CONSTRAINT inventories_pk PRIMARY KEY (vin, scraped_month)
     )
     """)
 
@@ -58,8 +60,8 @@ class DealershipsScraperPipeline:
             , vehicle_type, interior_color, exterior_color
             , transmission, engine, drivetrain, dealership_name
             , dealership_address, dealership_zipcode, dealership_city
-            , dealership_state, scraped_url, scraped_date)
-          VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            , dealership_state, scraped_url, scraped_date, scraped_month)
+          VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
       """,
       (
           item['vin'], item['title'], item['year'], item['make'], item['model']
@@ -68,7 +70,7 @@ class DealershipsScraperPipeline:
           , item['transmission'], item['engine'], item['drivetrain']
           , item['dealership_name'], item['dealership_address'], item['dealership_zipcode']
           , item['dealership_city'], item['dealership_state'], item['scraped_url']
-          , item['scraped_date']
+          , item['scraped_date'], beg_month
       ))
 
       ## Execute insert of data into database

--- a/sql_update_scripts/add_scraped_month.sql
+++ b/sql_update_scripts/add_scraped_month.sql
@@ -1,0 +1,12 @@
+alter table scraped_inventory_data.inventories add column scraped_month date;
+select scraped_date, scraped_month from scraped_inventory_data.inventories LIMIT 100;
+
+UPDATE scraped_inventory_data.inventories
+SET scraped_month = date_trunc('month', scraped_date);
+
+
+alter table scraped_inventory_data.inventories alter column scraped_month set not null;
+
+ALTER TABLE scraped_inventory_data.inventories
+  ADD CONSTRAINT inventories_pk
+    PRIMARY KEY (vin, scraped_month);

--- a/sql_update_scripts/create_backup_tbl.sql
+++ b/sql_update_scripts/create_backup_tbl.sql
@@ -1,0 +1,37 @@
+
+BEGIN TRANSACTION;
+
+drop table if exists scraped_inventory_data.inventories_backup;
+
+-- auto-generated definition
+create table scraped_inventory_data.inventories_backup
+(
+    vin                varchar not null,
+    title              varchar,
+    year               integer,
+    make               varchar,
+    model              varchar,
+    trim               varchar,
+    model_trim         varchar,
+    price              money,
+    mileage            integer,
+    vehicle_type       varchar,
+    interior_color     varchar,
+    exterior_color     varchar,
+    transmission       varchar,
+    engine             varchar,
+    drivetrain         varchar,
+    dealership_name    varchar,
+    dealership_address varchar,
+    dealership_zipcode varchar,
+    dealership_city    varchar,
+    dealership_state   varchar,
+    scraped_url        varchar,
+    scraped_date       timestamp,
+    scraped_month      date,
+    CONSTRAINT inventories_pk_backup PRIMARY KEY (vin, scraped_month)
+);
+
+insert into scraped_inventory_data.inventories_backup select * from scraped_inventory_data.inventories;
+
+COMMIT;


### PR DESCRIPTION
* Add scraped month to postgres db to create a pk based on vin and scraped month. For this table, we don't want the same vin for the same month that the vehicle was scraped.
* Modify pipeline to ensure we are inserting scraped month for each scraped item.